### PR TITLE
chore: adopt the pnpm supply-chain policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,12 @@
     "clean": "pnpm -r run clean",
     "build": "pnpm -r run build",
     "build:dev": "pnpm -r run build:dev",
-    "lint": "pnpm -r run lint"
+    "lint": "pnpm -r run lint",
+    "policy": "pnpm-policy generate",
+    "policy:check": "pnpm-policy check"
   },
   "devDependencies": {
+    "@constructive-io/pnpm-policy": "0.2.1",
     "@types/jest": "^29.5.14",
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.15.0",
@@ -31,9 +34,10 @@
     "eslint-plugin-unused-imports": "^4.3.0",
     "jest": "^29.7.0",
     "lerna": "^8.2.4",
-    "rimraf": "4.4.1",
     "pgsql-test": "^2.13.2",
+    "pnpm-policy": "^0.2.2",
     "prettier": "^3.3.3",
+    "rimraf": "4.4.1",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@constructive-io/pnpm-policy':
+        specifier: 0.2.1
+        version: 0.2.1
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -41,6 +44,9 @@ importers:
       pgsql-test:
         specifier: ^2.13.2
         version: 2.14.10(@babel/core@7.28.5)(@pgsql/types@17.6.1)(graphql@14.7.0)
+      pnpm-policy:
+        specifier: ^0.2.2
+        version: 0.2.2
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
@@ -467,6 +473,9 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@constructive-io/pnpm-policy@0.2.1':
+    resolution: {integrity: sha512-tAgH3Zgwn2shQXGlfl5zxmtY/tyZw9jYX7QAOFMp5ALKSrxO5xsxZQmckwMqOeHyyV/MZJWzIZ4t/QYznJeVmw==}
+
   '@cosmology/db-client@0.1.0':
     resolution: {integrity: sha512-CK+eHlp1TCWkV17EOyDQzxFRadHhmuqTx1GTAEr9pMF0ws9cAaJIxRYCIclitp8t8iXhG22DIRaOVUwbRzM/Kw==}
 
@@ -847,6 +856,7 @@ packages:
   '@lerna/create@8.2.4':
     resolution: {integrity: sha512-A8AlzetnS2WIuhijdAzKUyFpR5YbLLfV3luQ4lzBgIBgRfuoBDZeF+RSZPhra+7A6/zTUlrbhKZIOi/MNhqgvQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: This package is an implementation detail of Lerna and is no longer published separately.
 
   '@napi-rs/wasm-runtime@0.2.4':
     resolution: {integrity: sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ==}
@@ -943,24 +953,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@20.8.3':
     resolution: {integrity: sha512-LTTGzI8YVPlF1v0YlVf+exM+1q7rpsiUbjTTHJcfHFRU5t4BsiZD54K19Y1UBg1XFx5cwhEaIomSmJ88RwPPVQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@20.8.3':
     resolution: {integrity: sha512-SlA4GtXvQbSzSIWLgiIiLBOjdINPOUR/im+TUbaEMZ8wiGrOY8cnk0PVt95TIQJVBeXBCeb5HnoY0lHJpMOODg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@20.8.3':
     resolution: {integrity: sha512-MNzkEwPktp5SQH9dJDH2wP9hgG9LsBDhKJXJfKw6sUI/6qz5+/aAjFziKy+zBnhU4AO1yXt5qEWzR8lDcIriVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@20.8.3':
     resolution: {integrity: sha512-qUV7CyXKwRCM/lkvyS6Xa1MqgAuK5da6w27RAehh7LATBUKn1I4/M7DGn6L7ERCxpZuh1TrDz9pUzEy0R+Ekkg==}
@@ -1973,6 +1987,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -2560,6 +2575,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -2569,6 +2585,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -2586,6 +2603,7 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.0:
@@ -2594,11 +2612,12 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -3442,6 +3461,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  mkdirp@3.0.1:
+    resolution: {integrity: sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   modify-values@1.0.1:
     resolution: {integrity: sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==}
     engines: {node: '>=0.10.0'}
@@ -3482,6 +3506,9 @@ packages:
 
   nested-obj@0.1.1:
     resolution: {integrity: sha512-QNP5SWqeIxvJeXMLX89eM26jSOeA89pYVAyFK50tS7ZXPdB+WY1MhQGaHvReRu0pFRjZBGojNc66wumsj7ENxw==}
+
+  nested-obj@0.2.3:
+    resolution: {integrity: sha512-Py9HdJ/qECkQHvryUaPcaIou6t+U/mkpT66jG8al7jh8Opt3wAuTSSXdPDyY8r1ljEH8a0EH6M4YR28b+RQ8zg==}
 
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
@@ -3856,6 +3883,10 @@ packages:
   pluralize@7.0.0:
     resolution: {integrity: sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==}
     engines: {node: '>=4'}
+
+  pnpm-policy@0.2.2:
+    resolution: {integrity: sha512-Fj5/ACIZG/AGynTvhT8/7fJTf8ya3jG/Mkq/OMNVZhfTTJ1oniRTsKBHlXGF4sSecvIFqkmeHpn8CsQFwGcENA==}
+    hasBin: true
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -4352,6 +4383,7 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -4581,6 +4613,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -4706,6 +4739,14 @@ packages:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yamlize@0.12.1:
+    resolution: {integrity: sha512-rU2BN+gmyr0A4yK5i/Ps9JO1MjQGIGUelkaFglc9i4QqEDKU5HfDMdHhNhGMoeNeVw7nJqWpmDiFnxGb6FR5zA==}
 
   yanse@0.1.4:
     resolution: {integrity: sha512-gaRKNxhJGg3kAvMb2VNS7jyBBXWx6+z+rDcMJfXWyphBpSwiPfz7R/8N3pjgQg5mkPRziGR6NkBKxoHA72YTWg==}
@@ -5416,6 +5457,8 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@0.2.3': {}
+
+  '@constructive-io/pnpm-policy@0.2.1': {}
 
   '@cosmology/db-client@0.1.0':
     dependencies:
@@ -9209,6 +9252,8 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
+  mkdirp@3.0.1: {}
+
   modify-values@1.0.1: {}
 
   ms@2.0.0: {}
@@ -9238,6 +9283,8 @@ snapshots:
   neo-async@2.6.2: {}
 
   nested-obj@0.1.1: {}
+
+  nested-obj@0.2.3: {}
 
   node-fetch@2.6.7(encoding@0.1.13):
     dependencies:
@@ -9721,6 +9768,11 @@ snapshots:
       find-up: 4.1.0
 
   pluralize@7.0.0: {}
+
+  pnpm-policy@0.2.2:
+    dependencies:
+      yaml: 2.9.0
+      yamlize: 0.12.1
 
   postcss-selector-parser@6.1.2:
     dependencies:
@@ -10579,6 +10631,14 @@ snapshots:
   yallist@4.0.0: {}
 
   yaml@2.8.1: {}
+
+  yaml@2.9.0: {}
+
+  yamlize@0.12.1:
+    dependencies:
+      mkdirp: 3.0.1
+      nested-obj: 0.2.3
+      yaml: 2.9.0
 
   yanse@0.1.4: {}
 

--- a/pnpm-policy.yaml
+++ b/pnpm-policy.yaml
@@ -1,0 +1,41 @@
+# Supply-chain policy for this workspace. The pnpm settings it produces live in
+# pnpm-workspace.yaml under the `Managed by pnpm-policy` marker — edit this file,
+# then run `pnpm run policy`. `pnpm run policy:check` fails CI when they drift.
+
+# Third-party releases wait two days. A compromised release is normally reported
+# and yanked within hours, so the short wait catches it without stalling upgrades.
+minimumReleaseAge: 2d
+
+# Transitive dependencies must resolve from the registry, not from git or a URL.
+blockExoticSubdeps: true
+
+# The npm accounts WE publish under. Everything they publish skips the wait, so
+# this lists accounts we control — nobody else's.
+maintainers:
+  - pyramation
+
+# Scopes we own outright, emitted as `@scope/*` globs so they also cover packages
+# published there tomorrow.
+scopes:
+  - "@constructive-io"
+  - "@constructive-db"
+  - "@launchql"
+  - "@pgpm"
+  - "@pgpmjs"
+  - "@pgsql"
+
+# Resolved from the pinned data package rather than regenerated per repo.
+inventory: "@constructive-io/pnpm-policy/inventory.json"
+
+# Only emit the first-party names this lockfile actually resolves, instead of all
+# ~1100 we publish.
+intersect: true
+
+# Dependencies allowed to run install scripts. The value is the reason.
+allowBuilds:
+  esbuild: native binary, fetched by its install script
+  nx: native task-runner binary
+
+# Third-party escape hatches. A reason is required; `until` expires the waiver so
+# `check` makes you re-justify it instead of letting it live forever.
+exceptions: []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,44 @@
 packages:
   - 'packages/*'
+
+# The only dependencies permitted to run install scripts.
+allowBuilds:
+  esbuild: true # native binary, fetched by its install script
+  nx: true # native task-runner binary
+
+# Exempt from the wait: 6 scope glob(s), 18 first-party package(s).
+# First-party membership comes from what pyramation publishes on npm — waiting on your own release protects nothing.
+minimumReleaseAgeExclude:
+  - "@constructive-db/*"
+  - "@constructive-io/*"
+  - "@launchql/*"
+  - "@pgpm/*"
+  - "@pgpmjs/*"
+  - "@pgsql/*"
+  - "@cosmology/db-client"
+  - "@interweb/fetch-api-client"
+  - "@interweb/http-errors"
+  - "@pyramation/args"
+  - "@pyramation/prompt"
+  - csv-to-pg
+  - libpg-query
+  - nested-obj
+  - pg-ast
+  - pg-cache
+  - pg-env
+  - pgsql-deparser
+  - pgsql-enums
+  - pgsql-parser
+  - pgsql-test
+  - pnpm-policy
+  - yamlize
+  - yanse
+
+# Managed by pnpm-policy — run `pnpm-policy generate` after editing pnpm-policy.yaml.
+
+# A third-party release must be 2d old before it can be installed.
+# Most malicious releases are found and yanked well inside that window.
+minimumReleaseAge: 2880
+
+# Transitive dependencies must come from the registry, not from git or a URL.
+blockExoticSubdeps: true


### PR DESCRIPTION
Rolls this repo onto the org pnpm supply-chain policy. Part of the queue in constructive-io/constructive-planning#1464 (recipe A).

**What changes**

- `pnpm-policy.yaml` — 2d wait for third-party releases, `blockExoticSubdeps: true`, `intersect: true`.
- `pnpm-workspace.yaml` — generated block: 6 scope globs + 18 first-party packages exempt from the wait (873 omitted, since this workspace does not resolve them).
- `esbuild` and `nx` were already running install scripts here; they move into `allowBuilds` with a reason each.
- `@constructive-io/pnpm-policy` pinned exactly, so an inventory bump is a visible diff rather than a silent widening of what skips the wait.

**Verification**

```
pnpm run policy:check          ✓ pnpm-workspace.yaml matches the policy
pnpm install --frozen-lockfile ✓ succeeds
pnpm run policy                ✓ deterministic — second run byte-identical
```

**One deviation from the recipe:** step 5 adds `policy:check` to an existing lint or build CI job. This repo has no active workflow (`.github/workflows/` holds only `get-data.do-not-run-yml`), so there was nothing to attach it to and none was invented here. Until CI exists, drift between `pnpm-policy.yaml` and `pnpm-workspace.yaml` will not be caught automatically — worth a follow-up if this repo gets a pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CEswUi4ANuB58rva48aHge